### PR TITLE
fix nuxt component imports

### DIFF
--- a/lua/vue-goto-definition/import.lua
+++ b/lua/vue-goto-definition/import.lua
@@ -19,8 +19,8 @@ end
 
 local function handle_nuxt_imports(item, import, opts)
 	return opts.filters.auto_components
-			and item.filename:match(opts.filters.auto_components)
-			and import:gsub(opts.import_prefix, "")
+			and item.filename:match(opts.patterns.auto_components)
+			and import:gsub(opts.patterns.import_prefix, "")
 		or nil
 end
 


### PR DESCRIPTION
hello!

thanks for making this plugin :) I started working in a nuxt codebase recently, and it was annoying enough for me to seek this out

this is just a small PR to make the nuxt auto components work; I'm guessing these were just some typos since you said you don't work with nuxt

I'm currently using the plugin from my fork with the default config in the README and it works great!